### PR TITLE
feat: add date transformation for campaign receipts

### DIFF
--- a/src/core/constants/campaigns.constants.ts
+++ b/src/core/constants/campaigns.constants.ts
@@ -1,5 +1,6 @@
 import { MicrositeConfig, MicrositeDetails } from '@core/interfaces/campaigns.interfaces';
 import { VeryfiReceipt } from '@core/interfaces/veryfi.interfaces';
+import { transformDate } from '@shared/utils/date-transform';
 
 /**
  * ⚠️ IMPORTANTE ⚠️
@@ -37,7 +38,8 @@ const MICROSITE_CONFIG: MicrositeConfig = {
     },
     category: 'fisica',
     properties: (data: VeryfiReceipt) => {
-      return { ticket: data.id };
+      const date = transformDate(data.date);
+      return { ticket: data.id, secondary_date: date };
     },
   },
   ua: {
@@ -69,6 +71,10 @@ const MICROSITE_CONFIG: MicrositeConfig = {
       MANUAL_REVIEW: 'La factura ha sido marcada para revisión manual.',
     },
     category: 'fisica',
+    properties: (data: VeryfiReceipt) => {
+      const date = transformDate(data.date);
+      return { secondary_date: date };
+    },
   },
 };
 

--- a/src/core/constants/campaigns.contstants.spec.ts
+++ b/src/core/constants/campaigns.contstants.spec.ts
@@ -1,8 +1,16 @@
 import { VeryfiReceipt } from '@core/interfaces/veryfi.interfaces';
 import { getMicrositeConfig } from './campaigns.constants';
+import { transformDate } from '@shared/utils/date-transform';
+
+jest.mock('@shared/utils/date-transform', () => ({
+  transformDate: jest.fn(),
+}));
 
 describe('getMicrositeConfig', () => {
   it('should return the correct config for "sz"', () => {
+    const mockDate = new Date('2025-09-08T15:07:00Z');
+    (transformDate as jest.Mock).mockReturnValue(mockDate);
+
     const config = getMicrositeConfig('sz');
     expect(config).toBeDefined();
     expect(config.name).toEqual('TENA');
@@ -10,10 +18,17 @@ describe('getMicrositeConfig', () => {
     expect(config.uid).toEqual('nickname');
 
     if (typeof config.properties === 'function') {
-      const sampleReceipt: Partial<VeryfiReceipt> = { id: 12345 };
+      const sampleReceipt: Partial<VeryfiReceipt> = { id: 12345, date: '2025-09-08 15:07:00' };
 
       const props = config.properties(sampleReceipt as VeryfiReceipt);
-      expect(props).toEqual({ ticket: 12345 });
+
+      expect(props.ticket).toBe(12345);
+
+      expect(props.secondary_date).toBeInstanceOf(Date);
+      expect((props.secondary_date as Date).getTime()).toBe(mockDate.getTime());
+
+      expect(transformDate).toHaveBeenCalledTimes(1);
+      expect(transformDate).toHaveBeenCalledWith('2025-09-08 15:07:00');
     }
   });
 

--- a/src/shared/utils/date-transform.spec.ts
+++ b/src/shared/utils/date-transform.spec.ts
@@ -1,0 +1,9 @@
+import { transformDate } from './date-transform';
+
+describe('transformDate', () => {
+  it('should create an instance with the correct message', () => {
+    const date = transformDate('2025-10-27 16:30:00');
+
+    expect(date).toBeInstanceOf(Date);
+  });
+});

--- a/src/shared/utils/date-transform.ts
+++ b/src/shared/utils/date-transform.ts
@@ -1,0 +1,10 @@
+export const transformDate = (date: string): Date => {
+  const [dateString, timeString] = date.split(' ');
+
+  const [year, month, day] = dateString.split('-').map((item) => Number(item));
+  const [hours, minutes, seconds] = timeString.split(':').map((item) => Number(item));
+
+  const transformDate = new Date(Date.UTC(year, month - 1, day, hours, minutes, seconds));
+
+  return transformDate;
+};

--- a/src/superlikers/superlikers.service.ts
+++ b/src/superlikers/superlikers.service.ts
@@ -75,7 +75,13 @@ export class SuperlikersService {
 
     const url = `${SUPERLIKERS_URL}/retail/buy`;
 
-    const body = { api_key: SUPERLIKERS_API_KEY, campaign: SUPERLIKERS_CAMPAIGN_ID, distinct_id: uid, ref, products };
+    const body = {
+      api_key: SUPERLIKERS_API_KEY,
+      campaign: SUPERLIKERS_CAMPAIGN_ID,
+      distinct_id: uid,
+      ref,
+      products,
+    };
     if (date) body['date'] = date;
     if (properties) body['properties'] = properties;
     if (discount) body['discount'] = discount;


### PR DESCRIPTION
- Added new transformDate utility to convert string dates to UTC Date objects
- Updated campaign configs to include secondary_date property for both 'sz' and 'ua' microsites
- Added unit tests for date transformation functionality and updated campaign config tests
- Improved code formatting in superlikers service for better readability

The changes primarily add date handling capabilities to the campaign receipt processing system. The new transform