### PR TITLE
feat: include documentId in successful document processing response

### DIFF
--- a/src/core/services/document-processing/document-processing.service.spec.ts
+++ b/src/core/services/document-processing/document-processing.service.spec.ts
@@ -178,7 +178,7 @@ describe('DocumentProcessingService', () => {
         tag: 'points:10',
       });
 
-      expect(result).toEqual({ ok: true, message: 'La factura se subió correctamente.', points: 10 });
+      expect(result).toEqual({ ok: true, message: 'La factura se subió correctamente.', points: 10, documentId: 123 });
     });
 
     it('should handle errors and call handleHttpError', async () => {

--- a/src/core/services/document-processing/document-processing.service.ts
+++ b/src/core/services/document-processing/document-processing.service.ts
@@ -57,7 +57,7 @@ export class DocumentProcessingService {
 
       // Get sale information and register it in Superlikers
       const points = await this.processApprovedDocument(uid, document, campaign);
-      return { ok: true, message: 'La factura se subió correctamente.', points };
+      return { ok: true, message: 'La factura se subió correctamente.', points, documentId };
     } catch (err) {
       handleHttpError(err);
     }


### PR DESCRIPTION
- Added documentId to the response object returned after successful document upload
- Updated test expectations to include documentId in the success response